### PR TITLE
fix: correcciones de RC12, RC13, RC14, RC4b y RC16 - Primer Parcial

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ El proyecto utiliza metodologías ágiles de diseño como **Tarjetas CRC** (Clas
 
 | Nombre y Apellido | Matrícula | Usuario de GitHub | Rol pp|
 |:-----| -----: | ------: | :----: | 
-| Milenka Athina Vila | 157550 | @eternalnight04 |especialista de segregación de interfaces(ISP) |
-| Lautaro Chávez |151222 | @Lautarochavez14 |especialista en principios de extensión (ocp+ lsp) |
-| Alexis Matias Britez Acosta  | 158100| @britezacostaalexis-pixel |documentador y coordinador de repositorio(SRP) |
-|?   | ?    |    ?   |    ?    |
+| Milenka Athina Vila | 157550 | @eternalnight04 |Especialista de Segregación de Interfaces(ISP) |
+| Lautaro Chávez |151222 | @Lautarochavez14 |Especialista en Principios de Extensión (ocp+ lsp) |
+| Alexis Matias Britez Acosta  | 158100| @britezacostaalexis-pixel |Documentador y Coordinador de Repositorio(SRP) |
+| Milenka Athina Vila | 157550    |   @eternalnight04  |   Especialista en Inversión de Dependencias(DIP)   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ El proyecto utiliza metodologías ágiles de diseño como **Tarjetas CRC** (Clas
 
 ## Integrantes
 
-| Nombre y Apellido | Matrícula | Usuario de GitHub | Rol |
+| Nombre y Apellido | Matrícula | Usuario de GitHub | Rol pp|
 |:-----| -----: | ------: | :----: | 
-| Alejo Neicuan | 159810 | @ANeicuan | Diseñador de tarjetas CRC |
-| Sofía Sol Nestmann| 160130 | @sofinestt | Modeladora de Casos de Uso |
-| Alejo Neicuan | 159810 | @ANeicuan | Especialista en Escenarios de casos de uso |
-| Sofía Sol Nestmann| 160130 | @sofinestt | Documentadora y Coordinadora del Repositorio |
+| Milenka Athina Vila | 157550 | @eternalnight04 |especialista de segregación de interfaces(ISP) |
+| Lautaro Chávez |151222 | @Lautarochavez14 |especialista en principios de extensión (ocp+ lsp) |
+| Alexis Matias Britez Acosta  | 158100| @britezacostaalexis-pixel |documentador y coordinador de repositorio(SRP) |
+|?   | ?    |    ?   |    ?    |
 
 ---
 

--- a/anexos/principios-solid/02-ocp.md
+++ b/anexos/principios-solid/02-ocp.md
@@ -1,4 +1,4 @@
-# Principios Abierto/Cerrado (OCP)
+# Principio Abierto/Cerrado (OCP)
 
 ## Propósito y Tipo del principio SOLID
 El principio de Abierto/Cerrado (OCP) implica que el comportamiento de un módulo puede ser extendido para satisfacer nuevos requerimientos sin necesidad de alterar su código fuente original.

--- a/anexos/principios-solid/02-ocp.md
+++ b/anexos/principios-solid/02-ocp.md
@@ -19,9 +19,9 @@ En el Sistema de Turnos se aplica en dos casos principales:
 - `tipoConsulta`(superclase abstracta)
 - `Control`,`PrimeraVez`,`Sobreturno`(subclases)
 
-- 2.Disponibilidad
-- `Agenda`(superclase abstracta)
-- `medico`,`secretaria`(subclases)
+- 2 Disponibilidad
+  - `ReglaDisponibilidad` (superclase abstracta)
+  - `DisponibilidadMedico`, `DisponibilidadSecretaria` (subclases)
 
 
 

--- a/anexos/principios-solid/03-lsp.md
+++ b/anexos/principios-solid/03-lsp.md
@@ -2,38 +2,53 @@
 
 ## Propósito y Tipo del Principio SOLID
 
-El Principio de Sustitución de Liskov (LSP) es uno de los cinco principios SOLID en el diseño orientado a objetos. Establece que los objetos de una superclase deben poder ser reemplazados por objetos de sus subclases sin alterar el funcionamiento correcto del programa. En otras palabras, si S es una subclase de T, entonces los objetos de tipo T deberían poder ser reemplazados por objetos de tipo S sin modificar las propiedades correctas del programa. Este principio ayuda a prevenir violaciones sutiles en las jerarquías de herencia que pueden llevar a comportamientos inesperados y errores difíciles de detectar.
+El principio de sustitución de Liskov (LSP) establece que los objetos de una superclase deben poder ser reemplazados por objetos de sus subclases sin alterar el funcionamiento correcto del programa.
+
+En otras palabras: si `S` es una subclase de `T`, entonces los objetos de tipo `T` deberían poder ser reemplazados por objetos de tipo `S` sin modificar las propiedades correctas del programa.
 
 ## Motivación
 
-En el diseño orientado a objetos, las jerarquías de herencia pueden parecer correctas a simple vista, pero pueden ocultar violaciones del contrato entre clases. LSP nos ayuda a detectar estas violaciones asegurando que las subclases mantengan el comportamiento esperado de sus superclases.
+En el Sistema de Turnos Médicos es necesario trabajar de forma polimórfica con diferentes actores del sistema. Por este motivo se creó la jerarquía `Persona` → `Paciente`, `Medico`, `Secretaria`.
 
-En el sistema de turnos médicos, un ejemplo claro de la necesidad de aplicar LSP se encuentra en la jerarquía de clases Persona. Consideremos la jerarquía Persona → Paciente, Medico, Secretaria. La clase Secretaria hereda de Persona pero no agrega propiedades nuevas, solo hereda los datos básicos (nombre, apellido, telefono, mail). Esto plantea un problema: si el código cliente espera que las subclases de Persona tengan comportamientos distintivos o propiedades adicionales, la sustitución de Persona por Secretaria podría no funcionar como esperado, violando LSP.
-
-Por ejemplo, si tenemos un método que procesa roles basándose en el tipo de subclase, como autorizar sobreturnos para Médicos, el uso de polimorfismo se rompe si dependemos de instanceof, lo que indica una violación de LSP.
+La necesidad de aplicar LSP surge cuando queremos, por ejemplo, que la clase `Agenda` o `LlegadaPaciente` puedan recibir cualquier tipo de `Persona` sin tener que hacer comprobaciones de tipo (`instanceof`) ni casts.
 
 ## Explicación de Herencia
 
-La herencia en programación orientada a objetos es un mecanismo que permite a una clase (subclase) heredar propiedades y métodos de otra clase (superclase), promoviendo la reutilización de código y la creación de jerarquías. Para cumplir con LSP, la herencia debe usarse de manera que las subclases puedan sustituir a sus superclases sin alterar el comportamiento esperado. Esto significa que las subclases deben respetar el contrato de la superclase, incluyendo precondiciones, postcondiciones y invariantes.
+### Jerarquía propuesta: Persona → Paciente, Médico, Secretaria
 
-En el diseño de jerarquías del sistema de turnos, la herencia se aplica para modelar relaciones "es-un" válidas. Por ejemplo, un Paciente "es una" Persona, por lo que hereda los datos personales y agrega comportamientos específicos como pedirTurno(). Sin embargo, si una subclase como Secretaria no extiende el comportamiento de manera significativa, podría indicar que la herencia no es apropiada y que se debería considerar composición en su lugar.
+- **Superclase**: `Persona`
+- **Subclases**: `Paciente`, `Medico`, `Secretaria`
 
-## Estructura de Clases
+**Contrato de la superclase `Persona`**:
+- `getNombreCompleto()`
+- `getTelefono()`
+- `getEmail()`
+- `notificar()`
+- `registrarLlegada()`
 
-A continuación, se presenta un diagrama UML que ilustra la jerarquía de clases Persona y sus subclases, destacando cómo las subclases pueden (o no) sustituir a la superclase sin alterar el comportamiento esperado.
+Las subclases heredan estos métodos y agregan atributos específicos:
+- `Paciente`: dni, obraSocial, historiaClinica
+- `Medico`: matricula, especialidad
+- `Secretaria`: sector, legajo
 
-![Diagrama LSP](diagramas/01-diagrama-clases/01-solid-03-lsp.png)
+## Justificación Técnica usando clases reales del STM
 
-El diagrama PlantUML correspondiente se encuentra en [diagramas/01-diagrama-clases/01-solid-03-lsp.puml](diagramas/01-diagrama-clases/01-solid-03-lsp.puml).
+La jerarquía cumple con LSP porque:
 
-## Justificación Técnica
+- Cualquier método que espere una `Persona` puede recibir un `Paciente`, `Medico` o `Secretaria` sin romper el comportamiento.
+- Las subclases respetan el contrato de la superclase (no fortalecen precondiciones ni debilitan postcondiciones).
+- Permite que clases como `Agenda`, `Turno` y `LlegadaPaciente` trabajen con polimorfismo de forma segura.
 
-El diagrama UML muestra la jerarquía Persona como superclase abstracta con atributos comunes (nombre, apellido, telefono, mail) y métodos getters. Las subclases Paciente, Medico y Secretaria heredan de Persona.
+**Ejemplo real del proyecto:**
+```java
+// Ejemplo en LlegadaPaciente o Agenda
+public void procesarLlegada(Persona persona, Turno turno) {
+    persona.registrarLlegada();
+    turno.confirmarLlegada();
+    System.out.println("Llegada procesada para: " + persona.getNombreCompleto());
+}
 
-- **Paciente**: Agrega atributos específicos (dni, fechaNacimiento) y métodos como pedirTurno() y cancelarTurno(). Cumple con LSP porque extiende el contrato de Persona con comportamiento adicional sin alterar el esperado.
-
-- **Medico**: Agrega especialidad, matricula y métodos como consultarAgenda() y autorizarSobreturno(). También cumple LSP al mantener la sustituibilidad.
-
-- **Secretaria**: No agrega atributos nuevos, solo métodos operativos como gestionarTurnos(). Esto representa un problema LSP porque es un "falso subtipo": hereda datos pero no extiende significativamente el contrato. En el dominio, Secretaria es un rol operativo, no una entidad con estado propio, lo que sugiere usar composición en lugar de herencia.
-
-La solución propuesta es correcta técnicamente porque identifica la violación y recomienda composición para Secretaria, preservando LSP al evitar herencias inválidas. Las clases Paciente y Medico demuestran sustitución válida, mientras que Secretaria ilustra el riesgo de herencia inapropiada. Esto asegura que el código cliente pueda usar objetos de subclases indistintamente sin sorpresas, manteniendo la robustez del sistema.
+// Funciona con cualquier subtipo
+procesarLlegada(new Paciente(...), turnoActual);
+procesarLlegada(new Medico(...), turnoActual);
+procesarLlegada(new Secretaria(...), turnoActual);

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,12 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 - @sofinestt (Especialista en Inversion de Dependencias) — Se agregó documentación del uso de IA y aplicación del DIP, se actualizó el principio DIP y se modificó el diagrama de clases del módulo de notificaciones. PR [#56](https://github.com/sofinestt/SistemaTurnosMedicos/pull/56)
 
-- @sofinestt (Especialista en Segregacion de Interfaces) —  PR [#56](https://github.com/sofinestt/SistemaTurnosMedicos/pull/56)
+- @sofinestt (Especialista en Segregacion de Interfaces) — Se agregó documentación del uso de IA y ISP, se actualizó el principio de ISP y se modificó el diagrama de clases del módulo de notificaciones. PR [#56](https://github.com/sofinestt/SistemaTurnosMedicos/pull/56)
+
+### Fixed
+- [fix/correcciones-primer-parcial-2] Correcciones RC Primer Parcial: RC12, RC13, RC14, RC4b y RC16. PR: [#71](https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/71) - @britezacostaalexis-pixel
+
+
 
 - [feature/feature/esp-isp-add-anexo-isp1] Se agregó documentación del uso de IA y ISP, se actualizó el principio de ISP y se modificó el diagrama de clases del módulo de notificaciones. PR: [#64](https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/64) - @sofinestt (Especialista en Segregación de Interfaces)
 
@@ -84,3 +89,4 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [#73](https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/73)
 - [#74](https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/74)
   
+

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 ### Fixed
 - [fix/correcciones-primer-parcial-2] Correcciones RC Primer Parcial: RC12, RC13, RC14, RC4b y RC16. PR: [#71](https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/71) - @britezacostaalexis-pixel
 
+-[fix/primer-parcial-2]Correcciones RC primer parcial:RC1,RC2;RC4;RC4b,RC6 y RC8.PR:[#68] (https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/68) - @eternalnight04
+
+-[fix/rc17-correcciones] correccion rc17.PR:[#73] (https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/73#issue-4380477561) - @lautarochavez14
 
 
 - [feature/feature/esp-isp-add-anexo-isp1] Se agregó documentación del uso de IA y ISP, se actualizó el principio de ISP y se modificó el diagrama de clases del módulo de notificaciones. PR: [#64](https://github.com/britezacostaalexis-pixel/SistemaTurnosMedicos/pull/64) - @sofinestt (Especialista en Segregación de Interfaces)


### PR DESCRIPTION
### Correcciones realizadas:

- **RC12**: Corregida jerarquía semánticamente incorrecta (Agenda ya no hereda de Médico/Secretaria)
- **RC13**: Agregada columna "Rol PP" en tabla de integrantes, link a principios SOLID 
- **RC14**: Título cambiado a singular "Principio Abierto/Cerrado (OCP)"
- **RC4b**: Reescritura completa de ejemplos en 03-lsp.md usando clases reales del Sistema de Turnos Médicos (Persona, Paciente, Médico, etc.)
- **RC16**: Corregido template y descripción del PR para que refleje Primer Parcial

Se actualizó también el changelog.

**Branch:** `fix/correcciones-primer-parcial-2`